### PR TITLE
Proloy test

### DIFF
--- a/eelbrain/_stats/testnd.py
+++ b/eelbrain/_stats/testnd.py
@@ -730,7 +730,7 @@ class NDDifferenceTest(NDTest):
         """
         self._assert_has_cdist()
         if not 1 >= p > 0:
-            raise ValueError(f"pmin={pmin}: needs to be between 1 and 0")
+            raise ValueError(f"p={p}: needs to be between 1 and 0")
         if p == 1:
             if self._cdist.kind != 'cluster':
                 raise ValueError(f"p=1 is only a valid mask for threshold-based cluster tests")

--- a/eelbrain/plot/tests/test_glassbrain.py
+++ b/eelbrain/plot/tests/test_glassbrain.py
@@ -8,13 +8,18 @@ def test_glassbrain():
     ndvar = datasets.get_mne_stc(True, True)
 
     # source space only
-    p = plot.GlassBrain(ndvar.source, show=False)
+    p = plot.GlassBrain(ndvar.source)
     p.close()
 
     # single time points
-    p = plot.GlassBrain(ndvar.sub(time=0.030), show=False)
+    ndvar_30 = ndvar.sub(time=0.030)
+    p = plot.GlassBrain(ndvar_30)
+    p.close()
+    # without arrows
+    p = plot.GlassBrain(ndvar_30, draw_arrows=False)
     p.close()
 
     # time series
-    p = plot.GlassBrain(ndvar.sub(time=0.030), show=False)
+    p = plot.GlassBrain(ndvar)
+    p.set_time(.03)
     p.close()


### PR DESCRIPTION
This is modifying the test to check draw_arrows on and off. Basically, each submodule has tests in its corresponding `tests` folder. It's always a tradeoff between tests not running too long and covering as many features as possible, although with plots we can't really test that they look right, just that they don't error... You could run just this test (form the Eelbrian root folder)
```bash
$ pytest eelbrain/plot/tests/test_glassbrain.py
```

or all tests with 
```
$ make test
```
